### PR TITLE
4 Stable release v4.4

### DIFF
--- a/__modules__/defaultConfigLoader.py
+++ b/__modules__/defaultConfigLoader.py
@@ -6,12 +6,16 @@ Edited on Wed Mar  9 05:38:58 2022
 
 @author: dmytrenko.o
 """
-import os
+import os, sys
 from __modules__ import packagesInstaller
 packages = ['json']
 packagesInstaller.setup_packeges(packages)
 
 import json
+
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
 
 def dir_below():
     curFolder = os.path.abspath(os.getcwd()).replace(os.path.dirname(os.path.abspath(os.curdir)),"")

--- a/__modules__/defaultModelsLoader.py
+++ b/__modules__/defaultModelsLoader.py
@@ -16,13 +16,17 @@ from __modules__ import packagesInstaller, textProcessor
 packages = ['subprocess', 'pymorphy2', 'nltk', 'spacy', 'stanza']
 packagesInstaller.setup_packeges(packages)
 
-import subprocess
+import subprocess, sys
 from pymorphy2 import MorphAnalyzer
 import nltk, spacy, stanza
 
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
+
 def pymorphy2_model_loader(defaultLangs, nlpModels, lang):
     try:
-        subprocess.run('pip install -U pymorphy2-dicts-'+lang, shell=True)
+        subprocess.run("pip install -U pymorphy2-dicts-"+lang+"| grep -v 'already satisfied'", shell=True)
         print ("'{0}' language model for '{1}' package was downloaded successfully!".format(lang, defaultLangs[lang]))
     except:
         print ("Error! '{0}' language model for '{1}' package can not be dowloaded!".format(lang, defaultLangs[lang]))
@@ -55,12 +59,12 @@ def nltk_model_loader(defaultLangs, nlpModels, lang):
 
 def spacy_model_loader(defaultLangs, nlpModels, lang):
     try:
-        subprocess.run("python -m spacy download {0}_core_news_sm".format(lang), shell=True)
+        subprocess.run("python -m spacy download {0}_core_news_sm | grep -v 'already satisfied'".format(lang), shell=True)
         print ("'{0}' language model for '{1}' package was downloaded successfully!".format(lang, defaultLangs[lang]))     
     except:
         print ("Error! '{0}' language model for '{1}' package can not be dowloaded!".format(lang, defaultLangs[lang]))
         print ("Alternative {0} package downloading...".format(defaultLangs[lang]))
-        subprocess.run("python -m spacy download {0}_core_web_sm".format(lang), shell=True)
+        subprocess.run("python -m spacy download {0}_core_web_sm | grep -v 'already satisfied'".format(lang), shell=True)
         print ("'{0}' language model for '{1}' package was downloaded successfully!".format(lang, defaultLangs[lang]))
         pass
     try:

--- a/__modules__/defaultSWsLoader.py
+++ b/__modules__/defaultSWsLoader.py
@@ -15,8 +15,12 @@ from __modules__ import packagesInstaller, textProcessor
 packages = ['os', 'io', 'stop_words']
 packagesInstaller.setup_packeges(packages)
 
-import os, io
+import os, io, sys
 from stop_words import safe_get_stop_words
+
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
 
 def load_stop_words(defaultLangs, defaultSWs, lang):
     if os.path.isfile(lang+'.txt'):

--- a/__modules__/packagesInstaller.py
+++ b/__modules__/packagesInstaller.py
@@ -11,6 +11,10 @@ import sys
 import importlib
 import subprocess
 
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
+
 def setup_packeges(packages):
     for package in packages:
         if package in sys.modules:

--- a/__modules__/termsRanker.py
+++ b/__modules__/termsRanker.py
@@ -8,11 +8,16 @@ Edited on Wed Mar  9 09:03:15 2022
 @author: Олег Дмитренко
 
 """      
+import sys
 from __modules__ import packagesInstaller
 packages = ['nltk']
 packagesInstaller.setup_packeges(packages)
 
 from nltk import FreqDist
+
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
 
 def stanza_most_freq(keyTerms, top):
     mostFreqKeyTerms = ''
@@ -21,11 +26,13 @@ def stanza_most_freq(keyTerms, top):
         mostFreqKeyTerms = mostFreqKeyTerms + term  + ', ' 
     return mostFreqKeyTerms[:-2]
 
-def stanza_most_freq_key_terms(Words, Bigrams, Threegrams, top, outFlow):
-    outFlow.write(stanza_most_freq(Words,top)+'\n')
-    outFlow.write(stanza_most_freq(Bigrams, top)+'\n')
-    outFlow.write(stanza_most_freq(Threegrams,top)+'\n')
-    outFlow.write('***'+'\n')
+def stanza_most_freq_key_terms(Words, Bigrams, Threegrams, top):
+    sys.stdout = sys.__stdout__
+    print('<words>'+stanza_most_freq(Words,top)+'</words>')
+    print('<bigrams>'+stanza_most_freq(Bigrams, top)+'</bigrams>')
+    print('<threegrams>'+stanza_most_freq(Threegrams,top)+'</threegrams>')
+    print('***')
+    sys.stdout = stdOutput
     return
 
 def get_key(d, value):
@@ -40,11 +47,13 @@ def pymorphy2_most_freq(keyTerms, STerms, top):
         mostFreqKeyTerms = mostFreqKeyTerms + str(get_key(STerms, term))  + ', ' 
     return mostFreqKeyTerms[:-2]
 
-def pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams, top, outFlow):
-    outFlow.write(pymorphy2_most_freq(Words, SWords, top)+'\n')
-    outFlow.write(pymorphy2_most_freq(Bigrams, SBigrams, top)+'\n')
-    outFlow.write(pymorphy2_most_freq(Threegrams, SThreegrams, top)+'\n')
-    outFlow.write('***'+'\n')
+def pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams, top):
+    sys.stdout = sys.__stdout__
+    print('<words>'+pymorphy2_most_freq(Words, SWords, top)+'</words>')
+    print('<bigrams>'+pymorphy2_most_freq(Bigrams, SBigrams, top)+'</bigrams>')
+    print('<threegrams>'+pymorphy2_most_freq(Threegrams, SThreegrams, top)+'</threegrams>')
+    print('***')
+    sys.stdout = stdOutput
     return
 
 #def most_freq_key_terms_(nGrams, top):

--- a/__modules__/textProcessor.py
+++ b/__modules__/textProcessor.py
@@ -14,10 +14,14 @@ from __modules__ import packagesInstaller
 packages = ['fasttext', 'nltk']
 packagesInstaller.setup_packeges(packages)
 
-import fasttext
+import fasttext, sys
 from nltk.tokenize import sent_tokenize
 from nltk.tokenize import word_tokenize
 from __modules__ import defaultModelsLoader, defaultSWsLoader
+
+stdOutput = open("outlog.log", "a")
+sys.stderr = stdOutput
+sys.stdout = stdOutput
 
 def stanza_built_words(sent, Words, stopWords):
     WordsTags = []

--- a/main.py
+++ b/main.py
@@ -23,18 +23,14 @@ from __modules__ import defaultConfigLoader, defaultModelsLoader, defaultSWsLoad
 
 if __name__ == "__main__":
     inputFilePath = sys.argv[1]
-    outFileDir = sys.argv[2]
     #if start script in python compiler mode, 'spyder' for example, than comemnt 2 line above and recomment 2 line below
     #inputFileDir = '/Users/dmytrenko.o/Documents/GitHub/narrativesExtractor/datasets/otbor4.txt'
     #inputFilePath = '/Users/dmytrenko.o/Documents/GitHub/narrativesExtractor/datasets/20210126_.txt'
     #outFileDir = '/Users/dmytrenko.o/Documents/GitHub/narrativesExtractor/results/'
-    outFileDir = os.getcwd()+outFileDir
-    if not os.path.exists(outFileDir):
-        print ("Directory {0} don't exist!".format(outFileDir))
-        print ("Creating {0} directory...".format(outFileDir))
-        os.mkdir(outFileDir)
-        print ("Directory {0} was created seccsesfuly!".format(outFileDir))
-    
+    stdOutput = open("outlog.log", "a")
+    sys.stderr = stdOutput
+    sys.stdout = stdOutput
+
     defaultLangs = defaultConfigLoader.load_default_languages()
     defaultSWs = defaultSWsLoader.load_default_stop_words(defaultLangs)
     nlpModels = defaultModelsLoader.load_default_models(defaultLangs)
@@ -44,33 +40,33 @@ if __name__ == "__main__":
         message = ""
         lines = (inputFlow.read().lower()).splitlines()
         for line in lines:
-            message += (line + ' ')
+            message += (line + '\n')
             if line == '***':
                 message = message[:-4]
                 if message:
-                    outFileName = os.path.basename(inputFilePath)
-                    with open(outFileDir+outFileName, "a", encoding="utf-8") as outFlow: 
-                        outFlow.write(message+'\n')
-                        message = message[0:defaultConfigLoader.default_int_value('maxMessLength')]             
-                        lang = textProcessor.lang_detect(message, defaultLangs, nlpModels, defaultSWs)
-                        if (not defaultLangs[lang]):
-                            message = ""
-                            continue
-                        if (defaultLangs[lang] == 'pymorphy2'):
-                            Words, SBigrams, Bigrams, SThreegrams, Threegrams  = textProcessor.pymorphy2_nlp(message, nlpModels[lang], defaultSWs[lang])    
-                            SWords = dict(list(zip(Words, Words)))
-                            termsRanker.pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams,
-                                                        defaultConfigLoader.default_int_value('maxNumNarratives'), outFlow)
-                        elif (defaultLangs[lang] == 'stanza'):
-                            Words, Bigrams, Threegrams  = textProcessor.stanza_nlp(message, nlpModels[lang], defaultSWs[lang])    
-                            termsRanker.stanza_most_freq_key_terms(Words, Bigrams, Threegrams,
-                                                        defaultConfigLoader.default_int_value('maxNumNarratives'), outFlow)
-                        elif (not defaultLangs[lang]):
-                            Words, SBigrams, Bigrams, SThreegrams, Threegrams  = textProcessor.pymorphy2_nlp(message, nlpModels['uk'], defaultSWs['uk'])    
-                            SWords = dict(list(zip(Words, Words)))
-                            termsRanker.pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams,
-                                                            defaultConfigLoader.default_int_value('maxNumNarratives'), outFlow)
-                    
+                    sys.stdout = sys.__stdout__
+                    print('<content>'+message+'</content>')
+                    sys.stdout = stdOutput
+                    message = message[0:defaultConfigLoader.default_int_value('maxMessLength')]             
+                    lang = textProcessor.lang_detect(message, defaultLangs, nlpModels, defaultSWs)
+                    if (not defaultLangs[lang]):
+                        message = ""
+                        continue
+                    if (defaultLangs[lang] == 'pymorphy2'):
+                        Words, SBigrams, Bigrams, SThreegrams, Threegrams  = textProcessor.pymorphy2_nlp(message, nlpModels[lang], defaultSWs[lang])    
+                        SWords = dict(list(zip(Words, Words)))
+                        termsRanker.pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams,
+                                                    defaultConfigLoader.default_int_value('maxNumNarratives'))
+                    elif (defaultLangs[lang] == 'stanza'):
+                        Words, Bigrams, Threegrams  = textProcessor.stanza_nlp(message, nlpModels[lang], defaultSWs[lang])    
+                        termsRanker.stanza_most_freq_key_terms(Words, Bigrams, Threegrams,
+                                                    defaultConfigLoader.default_int_value('maxNumNarratives'))
+                    elif (not defaultLangs[lang]):
+                        Words, SBigrams, Bigrams, SThreegrams, Threegrams  = textProcessor.pymorphy2_nlp(message, nlpModels['uk'], defaultSWs['uk'])    
+                        SWords = dict(list(zip(Words, Words)))
+                        termsRanker.pymorphy2_most_freq_key_terms(SWords, Words, SBigrams, Bigrams, SThreegrams, Threegrams,
+                                                        defaultConfigLoader.default_int_value('maxNumNarratives'))
+                
                 message = ""
         inputFlow.close()
     print ("\nYou are lucky! The program successfully finished!\n")


### PR DESCRIPTION
Replace "line + ' '" to "line + '\n'"
Add <words></words>, <bigrams></bigrams> and <threegrams></thregrams> tags to "pymorphy2_most_freq_key_terms()" and "stanza_most_freq_key_terms()"
Add <content></content> tag for message in "main.py"
Remove second parameter "outFileDir = sys.argv[2]" from "main.py"
Remove "outFileDir = os.getcwd()+outFileDir" from "main.py"
Remove "outFileName" from "main.py"
Remove checking "if not os.path.exists(outFileDir):" from "main.py"
Remove "outFlow" from "main.py"
Remove "outFileName" from "main.py"
Remove «outFlow» as additional parameter for «pymorphy2_most_freq_key_terms()» and «stanza_most_freq_key_terms()» in "termsRanker" module
Replace «outFlow.write()» on «print» in "main.py" and "termsRanker" module
Add ""outlog.log" for both "sys.stdout" and "sys.stderr"
Add "stdOutput = open("outlog.log", "a") sys.stderr = stdOutput sys.stdout = stdOutput" for each module
Add "sys.stdout = sys.__stdout__" before print results
Add "| grep -v 'already satisfied'"" to "subprocess,run" in "defaultModelsLoader"